### PR TITLE
Add connection pooling and resilience to database sources

### DIFF
--- a/DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs
+++ b/DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs
@@ -1,35 +1,54 @@
-﻿using System.Data.Common;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
 using DataAccessProvider.Core.Interfaces;
+using DataAccessProvider.Core.Types;
 
 namespace DataAccessProvider.Core.Abstractions;
 
 #region ExecuteMethods
 public abstract partial class BaseDatabaseSource<TParameter> : BaseSource
+    where TParameter : DbParameter
 {
+    /// <summary>
+    /// The connection string used for the database connection.
+    /// </summary>
+    protected string _connectionString { get; }
+
+    private readonly ConnectionPool _connectionPool;
+    private readonly ResiliencePolicy _resiliencePolicy;
+    private readonly DatabaseResilienceOptions _options;
+
+    protected BaseDatabaseSource(string connectionString, DatabaseResilienceOptions? options = null)
+    {
+        _connectionString = connectionString;
+        _options = options ?? DatabaseResilienceOptions.Default;
+        _connectionPool = new ConnectionPool(CreateConnection, _options.MaxPoolSize);
+        _resiliencePolicy = ResiliencePolicy.Create(_options);
+    }
+
+    protected abstract DbConnection CreateConnection();
+
+    public abstract DbCommand GetCommand(string query, DbConnection connection);
+
     protected override async Task<BaseDataSourceParams> ExecuteReader(BaseDataSourceParams @params)
     {
-        var sourceParams = @params as BaseDatabaseSourceParams<TParameter>;
-        if (sourceParams == null)
-        {
-            throw new ArgumentException("Invalid source parameters type.");
-        }
+        var sourceParams = @params as BaseDatabaseSourceParams<TParameter> ?? throw new ArgumentException("Invalid source parameters type.");
 
-        using (var connection = GetConnection())
+        return await ExecuteWithPolicyAsync(async () =>
         {
+            await using var lease = await _connectionPool.RentAsync();
+            var connection = lease.Connection;
+
             using (var command = GetCommand(sourceParams!.Query, connection))
             {
-                command.CommandTimeout = sourceParams.Timeout;
-                command.CommandType = sourceParams.CommandType;
-
-                if (sourceParams.Parameters != null)
-                    command.Parameters.AddRange(sourceParams.Parameters.ToArray());
+                PrepareCommand(command, sourceParams);
 
                 var resultSet = new Dictionary<int, List<Dictionary<string, object>>>();
-                await connection.OpenAsync();
+                await EnsureConnectionOpenAsync(connection);
                 using (var reader = await command.ExecuteReaderAsync())
                 {
                     int resultCount = 0;
@@ -40,58 +59,48 @@ public abstract partial class BaseDatabaseSource<TParameter> : BaseSource
                     }
                     while (await reader.NextResultAsync());
                 }
-                // Handle single result set or multiple result sets
+
                 if (resultSet.Count == 1)
                 {
                     var firstResultSet = resultSet[0];
 
-                    // Handle single row, empty result, or list
                     if (firstResultSet.Count == 1)
                     {
-                        // Return the single row
                         sourceParams.SetValue(firstResultSet[0]);
                     }
                     else if (firstResultSet.Count == 0)
                     {
-                        // Return an empty dictionary if no results
                         sourceParams.SetValue(new Dictionary<string, object>());
                     }
                     else
                     {
-                        // Return the entire list for multiple rows
                         sourceParams.SetValue(firstResultSet);
                     }
                 }
                 else if (resultSet.Count > 1)
                 {
-                    // Handle multiple result sets
                     sourceParams.SetValue(resultSet);
                 }
+
                 return sourceParams;
             }
-        }
+        });
     }
 
     protected override async Task<BaseDataSourceParams<TValue>> ExecuteReader<TValue>(BaseDataSourceParams @params)
     {
-        var sourceParams = @params as BaseDatabaseSourceParams<TParameter>;
-        if (sourceParams == null)
+        var sourceParams = @params as BaseDatabaseSourceParams<TParameter> ?? throw new ArgumentException("Invalid source parameters type.");
+
+        return await ExecuteWithPolicyAsync(async () =>
         {
-            throw new ArgumentException("Invalid source parameters type.");
-        }
-        using (var connection = GetConnection())
-        {
+            await using var lease = await _connectionPool.RentAsync();
+            var connection = lease.Connection;
+
             using (var command = GetCommand(sourceParams!.Query, connection))
             {
-                command.CommandTimeout = sourceParams.Timeout;
-                command.CommandType = sourceParams.CommandType;
+                PrepareCommand(command, sourceParams);
 
-                if (sourceParams.Parameters != null)
-                {
-                    command.Parameters.AddRange(sourceParams.Parameters.ToArray());
-                }
-
-                await connection.OpenAsync();
+                await EnsureConnectionOpenAsync(connection);
                 using (var reader = await command.ExecuteReaderAsync())
                 {
                     var result = await MaterializeAsync<TValue>(reader);
@@ -108,97 +117,75 @@ public abstract partial class BaseDatabaseSource<TParameter> : BaseSource
                     return (BaseDataSourceParams<TValue>)(object)sourceParams;
                 }
             }
-        }
+        });
     }
+
     protected async override Task<BaseDataSourceParams> ExecuteScalar(BaseDataSourceParams @params)
     {
-        var sourceParams = @params as BaseDatabaseSourceParams<TParameter>;
-        using (var connection = GetConnection())
+        var sourceParams = @params as BaseDatabaseSourceParams<TParameter> ?? throw new ArgumentException("Invalid source parameters type.");
+
+        return await ExecuteWithPolicyAsync(async () =>
         {
+            await using var lease = await _connectionPool.RentAsync();
+            var connection = lease.Connection;
             using (var command = GetCommand(sourceParams!.Query, connection))
             {
-                command.CommandTimeout = sourceParams.Timeout;
-                command.CommandType = sourceParams.CommandType;
+                PrepareCommand(command, sourceParams);
 
-                if (sourceParams.Parameters != null)
-                {
-                    command.Parameters.AddRange(sourceParams.Parameters.ToArray());
-                }
-                await connection.OpenAsync();
+                await EnsureConnectionOpenAsync(connection);
                 var result = await command.ExecuteScalarAsync();
                 sourceParams.SetValue(result!);
                 return (BaseDataSourceParams)(object)sourceParams!;
             }
-        }
+        });
     }
 
     protected async override Task<BaseDataSourceParams> ExecuteNonQuery(BaseDataSourceParams @params)
     {
-        var sourceParams = @params as BaseDatabaseSourceParams<TParameter>;
-        using (var connection = GetConnection())
+        var sourceParams = @params as BaseDatabaseSourceParams<TParameter> ?? throw new ArgumentException("Invalid source parameters type.");
+
+        return await ExecuteWithPolicyAsync(async () =>
         {
+            await using var lease = await _connectionPool.RentAsync();
+            var connection = lease.Connection;
+
             using (var command = GetCommand(sourceParams!.Query, connection))
             {
-                command.CommandTimeout = sourceParams.Timeout;
-                command.CommandType = sourceParams.CommandType;
-                if (sourceParams.Parameters != null)
-                    command.Parameters.AddRange(sourceParams.Parameters.ToArray());
+                PrepareCommand(command, sourceParams);
 
-                await connection.OpenAsync();
+                await EnsureConnectionOpenAsync(connection);
                 var affectedRows = await command.ExecuteNonQueryAsync();
                 sourceParams.SetValue(affectedRows);
                 sourceParams.AffectedRows = affectedRows;
                 return sourceParams;
             }
+        });
+    }
+
+    private static async Task EnsureConnectionOpenAsync(DbConnection connection)
+    {
+        if (connection.State != ConnectionState.Open)
+        {
+            await connection.OpenAsync();
         }
     }
-}
-#endregion ExecuteMethods
-#region Props
-/// <summary>
-/// Represents a base class for database sources, providing common database operations like ExecuteNonQuery, ExecuteReader, and ExecuteScalar.
-/// </summary>
-/// <typeparam name="TDatabaseSourceParams">The type of the database source parameters.</typeparam>
-public abstract partial class BaseDatabaseSource<TParameter>
-{
-    /// <summary>
-    /// The connection string used for the database connection.
-    /// </summary>
-    protected string _connectionString { get; }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BaseDatabase{TDataSourceType, TDbParameter}"/> class.
-    /// </summary>
-    /// <param name="connectionString">The database connection string.</param>
-    public BaseDatabaseSource(string connectionString)
+    private void PrepareCommand(DbCommand command, IBaseDatabaseSourceParams<TParameter> sourceParams)
     {
-        _connectionString = connectionString;
+        command.CommandTimeout = sourceParams.Timeout;
+        command.CommandType = sourceParams.CommandType;
+
+        if (sourceParams.Parameters != null && sourceParams.Parameters.Count > 0)
+        {
+            command.Parameters.AddRange(sourceParams.Parameters.ToArray());
+        }
     }
 
-    /// <summary>
-    /// Gets a new instance of a database connection. Must be implemented in derived classes.
-    /// </summary>
-    /// <returns>A <see cref="DbConnection"/> specific to the database.</returns>
-    public virtual DbConnection GetConnection()
+    private Task<TResult> ExecuteWithPolicyAsync<TResult>(Func<Task<TResult>> action)
     {
-        throw new NotImplementedException();
+        return _resiliencePolicy.ExecuteAsync(action);
     }
 
-    /// <summary>
-    /// Creates and returns a new command object for executing queries.
-    /// Must be implemented in derived classes.
-    /// </summary>
-    /// <param name="query">The SQL query or command text.</param>
-    /// <param name="connection">The open database connection.</param>
-    /// <returns>A <see cref="DbCommand"/> object for executing commands.</returns>
-    public abstract DbCommand GetCommand(string query, DbConnection connection);
-
-    /// <summary>
-    /// Reads the result set from a <see cref="DbDataReader"/> and maps it to a list of dictionaries.
-    /// Each dictionary represents a row, with column names as keys and the corresponding values as values.
-    /// </summary>
-    /// <param name="reader">The <see cref="DbDataReader"/> to read from.</param>
-    /// <returns>A list of dictionaries where each dictionary represents a row from the result set.</returns>
     protected async Task<List<Dictionary<string, object>>> ReadResultAsync(DbDataReader reader)
     {
         var schema = reader.GetColumnSchema();
@@ -225,8 +212,7 @@ public abstract partial class BaseDatabaseSource<TParameter>
         return result;
     }
 }
-
-#endregion 
+#endregion
 #region BaseDatabaseSource
 /// <summary>
 /// Represents a base class for database sources, providing common database operations like ExecuteNonQuery, ExecuteReader, and ExecuteScalar.
@@ -238,7 +224,7 @@ public abstract partial class BaseDatabaseSource<TParameter> : IDataSource
     public async Task<TBaseDataSourceParams> ExecuteScalarAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
        where TBaseDataSourceParams : BaseDataSourceParams
     {
-        return (TBaseDataSourceParams)await ExecuteScalar(@params);   
+        return (TBaseDataSourceParams)await ExecuteScalar(@params);
     }
     public async Task<TBaseDataSourceParams> ExecuteReaderAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
        where TBaseDataSourceParams : BaseDataSourceParams
@@ -343,24 +329,21 @@ public abstract partial class BaseDatabaseSource<TParameter> : IDataSource
 
     public async Task<BaseDataSourceParams<TValue>> ExecuteReaderAsync<TValue>(BaseDataSourceParams<TValue> @params) where TValue : class, new()
     {
-        var sourceParams = @params as BaseDatabaseSourceParams<TParameter,TValue>;
+        var sourceParams = @params as BaseDatabaseSourceParams<TParameter, TValue>;
         if (sourceParams == null)
         {
             throw new ArgumentException("Invalid source parameters type.");
         }
-        using (var connection = GetConnection())
+
+        return await ExecuteWithPolicyAsync(async () =>
         {
+            await using var lease = await _connectionPool.RentAsync();
+            var connection = lease.Connection;
             using (var command = GetCommand(sourceParams!.Query, connection))
             {
-                command.CommandTimeout = sourceParams.Timeout;
-                command.CommandType = sourceParams.CommandType;
+                PrepareCommand(command, sourceParams);
 
-                if (sourceParams.Parameters != null)
-                {
-                    command.Parameters.AddRange(sourceParams.Parameters.ToArray());
-                }
-
-                await connection.OpenAsync();
+                await EnsureConnectionOpenAsync(connection);
                 using (var reader = await command.ExecuteReaderAsync())
                 {
                     var result = await MaterializeAsync<TValue>(reader);
@@ -377,9 +360,7 @@ public abstract partial class BaseDatabaseSource<TParameter> : IDataSource
                     return (BaseDataSourceParams<TValue>)(object)sourceParams;
                 }
             }
-        }
-
-
+        });
     }
 
     private async Task<List<TValue>> MaterializeAsync<TValue>(DbDataReader reader) where TValue : class, new()
@@ -545,11 +526,11 @@ public abstract partial class BaseDatabaseSource<TParameter, TDatabaseSourcePara
     }
     public async Task<TDatabaseSourceParams> ExecuteScalarAsync(TDatabaseSourceParams @params)
     {
-        return (TDatabaseSourceParams)(object)await ExecuteScalar(@params);       
+        return (TDatabaseSourceParams)(object)await ExecuteScalar(@params);
     }
     async Task<BaseDataSourceParams<TValue>> IDataSource<TDatabaseSourceParams>.ExecuteReaderAsync<TValue>(TDatabaseSourceParams @params)
     {
         return await ExecuteReader<TValue>(@params!);
     }
 }
-#endregion BaseDatabaseSource<>  
+#endregion BaseDatabaseSource<>

--- a/DataAccessProvider.Core/DataAccessProvider.Core.csproj
+++ b/DataAccessProvider.Core/DataAccessProvider.Core.csproj
@@ -20,15 +20,16 @@
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Internal dependencies, marked as private -->
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
+        <ItemGroup>
+                <!-- Internal dependencies, marked as private -->
+                <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1">
+                        <PrivateAssets>all</PrivateAssets>
+                </PackageReference>
+                <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1">
+                        <PrivateAssets>all</PrivateAssets>
+                </PackageReference>
+                <PackageReference Include="Polly" Version="8.3.1" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />

--- a/DataAccessProvider.Core/Types/ConnectionPool.cs
+++ b/DataAccessProvider.Core/Types/ConnectionPool.cs
@@ -1,0 +1,123 @@
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Channels;
+
+namespace DataAccessProvider.Core.Types;
+
+public sealed class ConnectionPool
+{
+    private readonly Channel<DbConnection> _channel;
+    private readonly Func<DbConnection> _connectionFactory;
+    private readonly int _maxPoolSize;
+    private int _createdConnections;
+
+    public ConnectionPool(Func<DbConnection> connectionFactory, int maxPoolSize = 20)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        if (maxPoolSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxPoolSize), "Max pool size must be greater than zero.");
+        }
+
+        _maxPoolSize = maxPoolSize;
+        _channel = Channel.CreateBounded<DbConnection>(new BoundedChannelOptions(maxPoolSize)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite
+        });
+    }
+
+    public async ValueTask<PooledConnectionLease> RentAsync(CancellationToken cancellationToken = default)
+    {
+        if (_channel.Reader.TryRead(out var existing))
+        {
+            return new PooledConnectionLease(existing, this);
+        }
+
+        if (TryCreateConnection(out var newConnection))
+        {
+            return new PooledConnectionLease(newConnection, this);
+        }
+
+        var awaited = await _channel.Reader.ReadAsync(cancellationToken);
+        return new PooledConnectionLease(awaited, this);
+    }
+
+    private bool TryCreateConnection(out DbConnection connection)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _createdConnections);
+            if (current >= _maxPoolSize)
+            {
+                connection = null!;
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _createdConnections, current + 1, current) == current)
+            {
+                try
+                {
+                    connection = _connectionFactory();
+                    return true;
+                }
+                catch
+                {
+                    Interlocked.Decrement(ref _createdConnections);
+                    throw;
+                }
+            }
+        }
+    }
+
+    internal void Return(DbConnection connection)
+    {
+        if (connection.State == ConnectionState.Broken)
+        {
+            DisposeConnection(connection);
+            return;
+        }
+
+        if (!_channel.Writer.TryWrite(connection))
+        {
+            DisposeConnection(connection);
+        }
+    }
+
+    private void DisposeConnection(DbConnection connection)
+    {
+        try
+        {
+            connection.Dispose();
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _createdConnections);
+        }
+    }
+
+    public readonly struct PooledConnectionLease : IAsyncDisposable, IDisposable
+    {
+        private readonly ConnectionPool _pool;
+
+        public PooledConnectionLease(DbConnection connection, ConnectionPool pool)
+        {
+            Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+        }
+
+        public DbConnection Connection { get; }
+
+        public void Dispose()
+        {
+            _pool.Return(Connection);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/DataAccessProvider.Core/Types/DatabaseResilienceOptions.cs
+++ b/DataAccessProvider.Core/Types/DatabaseResilienceOptions.cs
@@ -1,0 +1,36 @@
+namespace DataAccessProvider.Core.Types;
+
+public sealed class DatabaseResilienceOptions
+{
+    public static DatabaseResilienceOptions Default { get; } = new();
+
+    /// <summary>
+    /// Maximum retry attempts when a transient failure occurs.
+    /// </summary>
+    public int MaxRetryCount { get; init; } = 3;
+
+    /// <summary>
+    /// Base delay used for exponential backoff between retries.
+    /// </summary>
+    public TimeSpan BaseDelay { get; init; } = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// The number of consecutive failures allowed before opening the circuit breaker.
+    /// </summary>
+    public int CircuitBreakerFailureThreshold { get; init; } = 5;
+
+    /// <summary>
+    /// The duration to keep the circuit open after the threshold is reached.
+    /// </summary>
+    public TimeSpan CircuitBreakerDuration { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Maximum number of database connections allowed in the pool.
+    /// </summary>
+    public int MaxPoolSize { get; init; } = 20;
+
+    /// <summary>
+    /// Adds randomness to retry delays to avoid thundering herd issues.
+    /// </summary>
+    public bool EnableJitter { get; init; } = true;
+}

--- a/DataAccessProvider.Core/Types/ResiliencePolicy.cs
+++ b/DataAccessProvider.Core/Types/ResiliencePolicy.cs
@@ -1,0 +1,52 @@
+using System.Data.Common;
+using Polly;
+
+namespace DataAccessProvider.Core.Types;
+
+public sealed class ResiliencePolicy
+{
+    private readonly AsyncPolicyWrap _policy;
+
+    private ResiliencePolicy(AsyncPolicyWrap policy)
+    {
+        _policy = policy;
+    }
+
+    public static ResiliencePolicy Create(DatabaseResilienceOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var retryPolicy = Policy
+            .Handle<DbException>()
+            .Or<TimeoutException>()
+            .WaitAndRetryAsync(
+                options.MaxRetryCount,
+                attempt => CalculateDelay(attempt, options),
+                (exception, _, attempt, _) =>
+                {
+                    // Hook for future logging
+                });
+
+        var circuitBreakerPolicy = Policy
+            .Handle<DbException>()
+            .Or<TimeoutException>()
+            .CircuitBreakerAsync(options.CircuitBreakerFailureThreshold, options.CircuitBreakerDuration);
+
+        return new ResiliencePolicy(Policy.WrapAsync(retryPolicy, circuitBreakerPolicy));
+    }
+
+    public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action)
+    {
+        return _policy.ExecuteAsync(action);
+    }
+
+    private static TimeSpan CalculateDelay(int attempt, DatabaseResilienceOptions options)
+    {
+        var exponentialBackoff = options.BaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1);
+        var jitter = options.EnableJitter ? Random.Shared.NextDouble() * options.BaseDelay.TotalMilliseconds : 0;
+        return TimeSpan.FromMilliseconds(exponentialBackoff + jitter);
+    }
+}

--- a/DataAccessProvider.MSSQL/MSSQLSource.cs
+++ b/DataAccessProvider.MSSQL/MSSQLSource.cs
@@ -11,7 +11,7 @@ public sealed class MSSQLSource : BaseDatabaseSource<SqlParameter, MSSQLSourcePa
 {
     public MSSQLSource(string connectionString) : base(connectionString) { }
 
-    public override DbConnection GetConnection()
+    protected override DbConnection CreateConnection()
     {
         return new SqlConnection(_connectionString);
     }

--- a/DataAccessProvider.MySql/MySQLSource.cs
+++ b/DataAccessProvider.MySql/MySQLSource.cs
@@ -11,7 +11,7 @@ public sealed class MySQLSource : BaseDatabaseSource<MySqlParameter,MySQLSourceP
 {
     public MySQLSource(string connectionString) : base(connectionString) { }
 
-    public override DbConnection GetConnection()
+    protected override DbConnection CreateConnection()
     {
         return new MySqlConnection(_connectionString);
     }

--- a/DataAccessProvider.Oracle/OracleSource.cs
+++ b/DataAccessProvider.Oracle/OracleSource.cs
@@ -11,7 +11,7 @@ public sealed class OracleSource : BaseDatabaseSource<OracleParameter, OracleSou
 {
     public OracleSource(string connectionString) : base(connectionString) { }
 
-    public override DbConnection GetConnection()
+    protected override DbConnection CreateConnection()
     {
         return new OracleConnection(_connectionString);
     }

--- a/DataAccessProvider.Postgres/PostgresSource.cs
+++ b/DataAccessProvider.Postgres/PostgresSource.cs
@@ -11,7 +11,7 @@ public sealed class PostgresSource : BaseDatabaseSource<NpgsqlParameter,Postgres
 {
     public PostgresSource(string connectionString) : base(connectionString) { }
 
-    public override DbConnection GetConnection()
+    protected override DbConnection CreateConnection()
     {
         return new NpgsqlConnection(_connectionString);
     }

--- a/DataAccessProvider.Snowflake/SnowflakeSource.cs
+++ b/DataAccessProvider.Snowflake/SnowflakeSource.cs
@@ -10,7 +10,7 @@ public sealed class SnowflakeSource : BaseDatabaseSource<SnowflakeDbParameter, S
 {
     public SnowflakeSource(string connectionString) : base(connectionString) { }
 
-    public override DbConnection GetConnection()
+    protected override DbConnection CreateConnection()
     {
         return new SnowflakeDbConnection(_connectionString);
     }


### PR DESCRIPTION
## Summary
- add shared connection pooling utility and resilience options
- wrap database operations with retry and circuit-breaker policies using Polly
- update database providers to build connections through the shared pool

## Testing
- dotnet build (fails: dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cced8d09c832480574e53650e265b)