### PR TITLE
Add timeout handling to resilience policy

### DIFF
--- a/DataAccessProvider.Core/Types/DatabaseResilienceOptions.cs
+++ b/DataAccessProvider.Core/Types/DatabaseResilienceOptions.cs
@@ -10,6 +10,11 @@ public sealed class DatabaseResilienceOptions
     public int MaxRetryCount { get; init; } = 3;
 
     /// <summary>
+    /// Maximum duration to wait for a single database operation before timing out.
+    /// </summary>
+    public TimeSpan OperationTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Base delay used for exponential backoff between retries.
     /// </summary>
     public TimeSpan BaseDelay { get; init; } = TimeSpan.FromMilliseconds(200);


### PR DESCRIPTION
## Summary
- add configurable operation timeout to database resilience options
- include timeouts in existing retry and circuit breaker policy for external database calls

## Testing
- dotnet build DataAccessProvider.sln *(fails: dotnet SDK not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ceb63a88483248ef08aa153a6acf6)