### PR TITLE
Add PostgreSQL provider integration and docs

### DIFF
--- a/DataAccessProvider.Postgres/PostgresSource.cs
+++ b/DataAccessProvider.Postgres/PostgresSource.cs
@@ -5,11 +5,12 @@ using System.Data.Common;
 
 namespace DataAccessProvider.Postgres;
 
-public sealed class PostgresSource : BaseDatabaseSource<NpgsqlParameter,PostgresSourceParams>,
+public sealed class PostgresSource : BaseDatabaseSource<NpgsqlParameter, PostgresSourceParams>,
     IDataSource,
     IDataSource<PostgresSourceParams>
 {
-    public PostgresSource(string connectionString) : base(connectionString) { }
+    public PostgresSource(string connectionString, IResiliencePolicy? resiliencePolicy = null)
+        : base(connectionString, resiliencePolicy) { }
 
     public override DbConnection GetConnection()
     {

--- a/DataAccessProvider.Postgres/README.md
+++ b/DataAccessProvider.Postgres/README.md
@@ -1,0 +1,72 @@
+﻿# DataAccessProvider.Postgres
+
+A PostgreSQL provider for the DataAccessProvider framework, built on top of the Npgsql driver. It offers async operations, parameterized queries, resilience support, and easy DI registration.
+
+## Installation
+
+```bash
+dotnet add package DataAccessProvider.Postgres
+```
+
+## Configuration
+
+Add a connection string named `PostgresSource` to your `appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "PostgresSource": "Host=localhost;Port=5432;Database=mydb;Username=myuser;Password=mypassword"
+  }
+}
+```
+
+## Dependency Injection
+
+```csharp
+// In Startup.cs or Program.cs
+services.AddDataAccessProviderCore(configuration);
+services.AddDataAccessProviderPostgres(configuration);
+
+// After building the provider
+serviceProvider.UseDataAccessProviderPostgres();
+```
+
+You can also register the provider with a raw connection string:
+
+```csharp
+services.AddDataAccessProviderPostgres("Host=localhost;Port=5432;Database=mydb;Username=myuser;Password=mypassword");
+```
+
+## Usage
+
+```csharp
+var dataSourceProvider = serviceProvider.GetRequiredService<IDataSourceProvider>();
+
+var queryParams = new PostgresSourceParams
+{
+    Query = "SELECT id, name FROM users WHERE id = @id",
+    Parameters = new List<NpgsqlParameter>
+    {
+        new("@id", 1)
+    }
+};
+
+var result = await dataSourceProvider.ExecuteReaderAsync(queryParams);
+```
+
+### Typed Results
+
+```csharp
+public record User(int Id, string Name);
+
+var typedParams = new PostgresSourceParams<User>
+{
+    Query = "SELECT id, name FROM users"
+};
+
+var users = await dataSourceProvider.ExecuteReaderAsync(typedParams);
+```
+
+## Resilience
+
+If you register an `IResiliencePolicy` (e.g., via `AddDataAccessProviderCore`), the provider will automatically apply retries/timeouts around database calls.

--- a/DataAccessProvider.Postgres/ServiceExtensions.cs
+++ b/DataAccessProvider.Postgres/ServiceExtensions.cs
@@ -1,0 +1,64 @@
+﻿using DataAccessProvider.Core.DataSource;
+using DataAccessProvider.Core.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace DataAccessProvider.Postgres;
+
+public static class ServiceExtensions
+{
+    public static IServiceCollection AddDataAccessProviderPostgres(this IServiceCollection service, IConfiguration configuration)
+    {
+        service.TryAddScoped<IDataSourceProvider, DataSourceProvider>();
+        service.TryAddScoped(typeof(IDataSourceProvider<>), typeof(DataSourceProvider<>));
+        service.TryAddSingleton<IDataSourceFactory, DataSourceFactory>();
+
+        string connectionString = configuration.GetConnectionString(nameof(PostgresSource)) ?? string.Empty;
+
+        service.AddScoped<IDataSource<PostgresSourceParams>>(sp =>
+        {
+            var policy = sp.GetService<IResiliencePolicy>();
+            return new PostgresSource(connectionString, policy);
+        });
+        service.AddScoped(sp =>
+        {
+            var policy = sp.GetService<IResiliencePolicy>();
+            return new PostgresSource(connectionString, policy);
+        });
+
+        return service;
+    }
+
+    public static IServiceCollection AddDataAccessProviderPostgres(this IServiceCollection service, string connectionString)
+    {
+        service.TryAddScoped<IDataSourceProvider, DataSourceProvider>();
+        service.TryAddScoped(typeof(IDataSourceProvider<>), typeof(DataSourceProvider<>));
+        service.TryAddSingleton<IDataSourceFactory, DataSourceFactory>();
+
+        service.AddScoped<IDataSource<PostgresSourceParams>>(sp =>
+        {
+            var policy = sp.GetService<IResiliencePolicy>();
+            return new PostgresSource(connectionString, policy);
+        });
+        service.AddScoped(sp =>
+        {
+            var policy = sp.GetService<IResiliencePolicy>();
+            return new PostgresSource(connectionString, policy);
+        });
+
+        return service;
+    }
+
+    /// <summary>
+    /// Registers the Postgres data source with the IDataSourceFactory.
+    /// </summary>
+    /// <param name="provider">The service provider.</param>
+    /// <returns>The service provider.</returns>
+    public static IServiceProvider UseDataAccessProviderPostgres(this IServiceProvider provider)
+    {
+        var factory = provider.GetRequiredService<IDataSourceFactory>();
+        factory.RegisterDataSource<PostgresSourceParams, PostgresSource>();
+        return provider;
+    }
+}

--- a/DataAccessProviderConsole/Setup/ServiceConfiguration.cs
+++ b/DataAccessProviderConsole/Setup/ServiceConfiguration.cs
@@ -1,8 +1,10 @@
 using DataAccessProvider.Core.Extensions;
 using DataAccessProvider.MSSQL;
 using DataAccessProvider.MySql;
+using DataAccessProvider.Postgres;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using DataAccessProvider.Core.Interfaces;
 
 namespace DataAccessProviderConsole.Setup;
 
@@ -38,6 +40,11 @@ public static class ServiceConfiguration
             services.AddDataAccessProviderMSSQL(sqlString);
         }
 
+        if (!string.IsNullOrWhiteSpace(postgresString))
+        {
+            services.AddDataAccessProviderPostgres(postgresString);
+        }
+
         //services.AddScoped<IDataSource, PostgresSource>();
         //services.AddScoped<IDataSource, OracleDataSource>();
         //services.AddScoped<IDataSource, MongoDBSource>();
@@ -49,7 +56,19 @@ public static class ServiceConfiguration
     public static void ConfigureProviders(ServiceProvider serviceProvider)
     {
         // These will work for whichever providers you actually registered above
-        serviceProvider.UseDataAccessProviderMSSQL();
-        serviceProvider.UseDataAccessProviderMySql();
+        if (serviceProvider.GetService<IDataSource<MSSQLSourceParams>>() is not null)
+        {
+            serviceProvider.UseDataAccessProviderMSSQL();
+        }
+
+        if (serviceProvider.GetService<IDataSource<MySQLSourceParams>>() is not null)
+        {
+            serviceProvider.UseDataAccessProviderMySql();
+        }
+
+        if (serviceProvider.GetService<IDataSource<PostgresSourceParams>>() is not null)
+        {
+            serviceProvider.UseDataAccessProviderPostgres();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ var mssqParams2 = new MSSQLSourceParams<Diary>
 };
 var result2 = await dataSourceProvider.ExecuteReaderAsync(mssqParams2);
 
+// Example 3: Execute a query using PostgresSourceParams
+var pgParams = new PostgresSourceParams
+{
+    Query = "SELECT id, title FROM diary LIMIT 1"
+};
+var pgResult = await dataSourceProvider.ExecuteReaderAsync(pgParams);
+
 // Example 3: Execute a query using StaticCodeParams (for static content)
 var codeParams = new StaticCodeParams
 {


### PR DESCRIPTION
## Summary
- add PostgreSQL registration helpers with resilience support for the provider
- register PostgreSQL in the sample console app when configured and guard factory registration
- document PostgreSQL usage and update the root README with a usage example

## Testing
- dotnet build DataAccessProvider.sln *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503c6ac9d48324a3cebe34c60084ce)