### PR TITLE
Add GitHub Action for NuGet publishing

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,36 @@
+name: Publish NuGet packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+env:
+  NUGET_SOURCE: https://api.nuget.org/v3/index.json
+  ARTIFACTS_DIR: ./artifacts
+
+jobs:
+  pack-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+          dotnet-quality: "preview"
+
+      - name: Restore dependencies
+        run: dotnet restore DataAccessProvider.sln
+
+      - name: Build solution
+        run: dotnet build DataAccessProvider.sln --configuration Release --no-restore
+
+      - name: Pack NuGet packages
+        run: dotnet pack DataAccessProvider.*/*.csproj --configuration Release --no-build --output "${{ env.ARTIFACTS_DIR }}"
+
+      - name: Publish packages to NuGet.org
+        run: dotnet nuget push "${{ env.ARTIFACTS_DIR }}/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source "${{ env.NUGET_SOURCE }}" --skip-duplicate


### PR DESCRIPTION
## Summary
- add a publish-nuget workflow triggered on tags or manual runs to build, pack, and push packages to NuGet.org

## Testing
- not run (CI workflow)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503c86c6fc83249dbae88f426db1c7)