### PR TITLE
Add parameter-aware IDataSource.CheckHealthAsync and file-path health for JsonFileSource

### DIFF
--- a/DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs
+++ b/DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs
@@ -281,6 +281,26 @@ public abstract partial class BaseDatabaseSource<TParameter>
 public abstract partial class BaseDatabaseSource<TParameter> : IDataSource
     where TParameter : DbParameter
 {
+    public async Task<bool> CheckHealthAsync()
+    {
+        try
+        {
+            using var connection = GetConnection();
+            await connection.OpenAsync().ConfigureAwait(false);
+            return connection.State == System.Data.ConnectionState.Open;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
+        where TBaseDataSourceParams : BaseDataSourceParams
+    {
+        return CheckHealthAsync();
+    }
+
     public async Task<TBaseDataSourceParams> ExecuteScalarAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
        where TBaseDataSourceParams : BaseDataSourceParams
     {

--- a/DataAccessProvider.Core/DataSource/DataSourceProvidercs.cs
+++ b/DataAccessProvider.Core/DataSource/DataSourceProvidercs.cs
@@ -44,6 +44,18 @@ namespace DataAccessProvider.Core.DataSource
         /// <exception cref="ArgumentException">
         /// Thrown if the data source type specified in <typeparamref name="TBaseDataSourceParams"/> is unsupported.
         /// </exception>
+        public Task<bool> CheckHealthAsync()
+        {
+            throw new NotSupportedException("Use CheckHealthAsync(params) when health validation requires source parameters.");
+        }
+
+        public Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
+            where TBaseDataSourceParams : BaseDataSourceParams
+        {
+            IDataSource dataSource = _sourceFactory.CreateDataSource(@params);
+            return dataSource.CheckHealthAsync(@params);
+        }
+
         public async Task<TBaseDataSourceParams> ExecuteNonQueryAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params) where TBaseDataSourceParams : BaseDataSourceParams
         {
             IDataSource dataSource = _sourceFactory.CreateDataSource(@params);

--- a/DataAccessProvider.Core/DataSource/Source/JsonFileSource.cs
+++ b/DataAccessProvider.Core/DataSource/Source/JsonFileSource.cs
@@ -116,6 +116,22 @@ public partial class JsonFileSource : BaseSource
 #region JsonFileSource
 public partial class JsonFileSource : IDataSource
 {
+    public Task<bool> CheckHealthAsync()
+    {
+        return Task.FromResult(false);
+    }
+
+    public Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
+        where TBaseDataSourceParams : BaseDataSourceParams
+    {
+        if (@params is JsonFileSourceParams jsonFileSourceParams)
+        {
+            return Task.FromResult(File.Exists(jsonFileSourceParams.FilePath));
+        }
+
+        return Task.FromResult(false);
+    }
+
     public async Task<TBaseDataSourceParams> ExecuteNonQueryAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params) where TBaseDataSourceParams : BaseDataSourceParams
     {
         return (TBaseDataSourceParams)await ExecuteNonQuery(@params);

--- a/DataAccessProvider.Core/DataSource/Source/StaticCodeSource.cs
+++ b/DataAccessProvider.Core/DataSource/Source/StaticCodeSource.cs
@@ -100,6 +100,17 @@ public partial class StaticCodeSource : BaseSource
 
 public partial class StaticCodeSource : IDataSource
 {
+    public Task<bool> CheckHealthAsync()
+    {
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
+        where TBaseDataSourceParams : BaseDataSourceParams
+    {
+        return Task.FromResult(true);
+    }
+
     public async Task<TBaseDataSourceParams> ExecuteNonQueryAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params) where TBaseDataSourceParams : BaseDataSourceParams
     {
         return (TBaseDataSourceParams)await ExecuteNonQuery(@params);

--- a/DataAccessProvider.Core/Interfaces/IDataSource.cs
+++ b/DataAccessProvider.Core/Interfaces/IDataSource.cs
@@ -5,6 +5,22 @@ namespace DataAccessProvider.Core.Interfaces;
 public interface IDataSource
 {
     /// <summary>
+    /// Checks whether the underlying data source connection can be opened successfully.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the connection can be opened; otherwise, <c>false</c>.
+    /// </returns>
+    Task<bool> CheckHealthAsync();
+
+    /// <summary>
+    /// Checks whether the underlying data source is healthy for the provided source parameters.
+    /// </summary>
+    /// <param name="params">The source parameters used to validate health.</param>
+    /// <returns><c>true</c> when healthy; otherwise, <c>false</c>.</returns>
+    Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
+        where TBaseDataSourceParams : BaseDataSourceParams;
+
+    /// <summary>
     /// Executes a query asynchronously, retrieves the result set, and maps it to a list of objects of type <typeparamref name="TValue"/>.
     /// This method uses the provided database parameters to execute the query and map the results into a collection of objects.
     /// </summary>

--- a/DataAccessProvider.MongoDB/MongoDBSource.cs
+++ b/DataAccessProvider.MongoDB/MongoDBSource.cs
@@ -334,6 +334,47 @@ public sealed class MongoDBSource : BaseSource, IDataSource, IDataSource<MongoDB
 
     #region IDataSource Implementation
 
+    public async Task<bool> CheckHealthAsync()
+    {
+        try
+        {
+            var database = GetDatabase();
+            var command = new BsonDocument("ping", 1);
+            await database.RunCommandAsync<BsonDocument>(command).ConfigureAwait(false);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
+        where TBaseDataSourceParams : BaseDataSourceParams
+    {
+        if (@params is MongoDBParams mongoParams)
+        {
+            return CheckMongoHealthAsync(mongoParams);
+        }
+
+        return Task.FromResult(false);
+    }
+
+    private async Task<bool> CheckMongoHealthAsync(MongoDBParams mongoParams)
+    {
+        try
+        {
+            var database = GetDatabase(mongoParams.DatabaseName);
+            var command = new BsonDocument("ping", 1);
+            await database.RunCommandAsync<BsonDocument>(command).ConfigureAwait(false);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public async Task<TBaseDataSourceParams> ExecuteNonQueryAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)
         where TBaseDataSourceParams : BaseDataSourceParams
     {


### PR DESCRIPTION
### Motivation
- Health checks need source-specific context (for example, a JSON file path) to determine readiness instead of a one-size-fits-all boolean.
- The provider layer should allow callers to ask a concrete data source to validate health using its configuration parameters.
- Database-backed sources should keep their existing connectivity checks while supporting parameter-aware calls.

### Description
- Added a generic overload `Task<bool> CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)` to `IDataSource` to allow parameter-aware health validation.
- `DataSourceProvider` now exposes `CheckHealthAsync<TBaseDataSourceParams>(TBaseDataSourceParams @params)` and delegates the call to the concrete `IDataSource` created from the supplied params, and its parameterless `CheckHealthAsync()` throws with guidance to use the params-aware overload.
- `JsonFileSource` now performs file-path validation when given `JsonFileSourceParams` by returning `File.Exists(jsonFileSourceParams.FilePath)` and its parameterless `CheckHealthAsync()` returns `false` to indicate health depends on params.
- `BaseDatabaseSource<TParameter>` delegates the generic overload to the existing connection-open check, `MongoDBSource` adds a params-aware path that pings the configured database (via a `CheckMongoHealthAsync` helper), and `StaticCodeSource` implements the new overload to maintain compatibility.

### Testing
- Attempted to run a solution build with `dotnet build DataAccessProvider.sln`, but the command failed because the `dotnet` CLI is not available in the execution environment (build not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5a043bd88324bd5fbd74de864ccb)