### PR TITLE
refactor: remove unused TParameter generic from BaseDatabaseSource

### DIFF
--- a/DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs
+++ b/DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs
@@ -9,7 +9,7 @@ using DataAccessProvider.Core.Types;
 namespace DataAccessProvider.Core.Abstractions;
 
 #region ExecuteMethods
-public abstract partial class BaseDatabaseSource<TParameter> : BaseSource
+public abstract partial class BaseDatabaseSource : BaseSource
 {
     protected override async Task<BaseDataSourceParams> ExecuteReader(BaseDataSourceParams @params)
     {
@@ -216,7 +216,7 @@ public abstract partial class BaseDatabaseSource<TParameter> : BaseSource
 /// Represents a base class for database sources, providing common database operations like ExecuteNonQuery, ExecuteReader, and ExecuteScalar.
 /// </summary>
 /// <typeparam name="TDatabaseSourceParams">The type of the database source parameters.</typeparam>
-public abstract partial class BaseDatabaseSource<TParameter>
+public abstract partial class BaseDatabaseSource
 {
     /// <summary>
     /// The connection string used for the database connection.
@@ -294,8 +294,7 @@ public abstract partial class BaseDatabaseSource<TParameter>
 /// Represents a base class for database sources, providing common database operations like ExecuteNonQuery, ExecuteReader, and ExecuteScalar.
 /// </summary>
 /// <typeparam name="TDatabaseSourceParams">The type of the database source parameters.</typeparam>
-public abstract partial class BaseDatabaseSource<TParameter> : IDataSource
-    where TParameter : DbParameter
+public abstract partial class BaseDatabaseSource : IDataSource
 {
     public async Task<bool> CheckHealthAsync()
     {
@@ -616,14 +615,13 @@ public abstract partial class BaseDatabaseSource<TParameter> : IDataSource
     }
 }
 #endregion BaseDatabaseSource
-#region BaseDatabaseSource<>
+#region BaseDatabaseSource<TDatabaseSourceParams>
 /// <summary>
 /// Represents a base class for database sources, providing common database operations like ExecuteNonQuery, ExecuteReader, and ExecuteScalar.
 /// </summary>
 /// <typeparam name="TDatabaseSourceParams">The type of the database source parameters.</typeparam>
-public abstract partial class BaseDatabaseSource<TParameter, TDatabaseSourceParams> : BaseDatabaseSource<TParameter>, IDataSource<TDatabaseSourceParams>
+public abstract partial class BaseDatabaseSource<TDatabaseSourceParams> : BaseDatabaseSource, IDataSource<TDatabaseSourceParams>
     where TDatabaseSourceParams : BaseDatabaseSourceParams
-    where TParameter : DbParameter
 {
     protected IResiliencePolicy? _resiliencePolicy { get; }
 
@@ -649,4 +647,4 @@ public abstract partial class BaseDatabaseSource<TParameter, TDatabaseSourcePara
         return await ExecuteReader<TValue>(@params!);
     }
 }
-#endregion BaseDatabaseSource<>  
+#endregion BaseDatabaseSource<TDatabaseSourceParams>  

--- a/DataAccessProvider.MSSQL/MSSQLSource.cs
+++ b/DataAccessProvider.MSSQL/MSSQLSource.cs
@@ -7,7 +7,7 @@ using System.Data.Common;
 
 namespace DataAccessProvider.MSSQL;
 
-public sealed class MSSQLSource : BaseDatabaseSource<SqlParameter, MSSQLSourceParams>,
+public sealed class MSSQLSource : BaseDatabaseSource<MSSQLSourceParams>,
     IDataSource,
     IDataSource<MSSQLSourceParams>
 {

--- a/DataAccessProvider.MySql/MySQLSource.cs
+++ b/DataAccessProvider.MySql/MySQLSource.cs
@@ -7,7 +7,7 @@ using System.Data.Common;
 
 namespace DataAccessProvider.MySql;
 
-public sealed class MySQLSource : BaseDatabaseSource<MySqlParameter, MySQLSourceParams>,
+public sealed class MySQLSource : BaseDatabaseSource<MySQLSourceParams>,
     IDataSource,
     IDataSource<MySQLSourceParams>
 {

--- a/DataAccessProvider.Oracle/OracleSource.cs
+++ b/DataAccessProvider.Oracle/OracleSource.cs
@@ -7,7 +7,7 @@ using System.Data.Common;
 
 namespace DataAccessProvider.Oracle;
 
-public sealed class OracleSource : BaseDatabaseSource<OracleParameter, OracleSourceParams>,
+public sealed class OracleSource : BaseDatabaseSource<OracleSourceParams>,
     IDataSource,
     IDataSource<OracleSourceParams>
 {

--- a/DataAccessProvider.Postgres/PostgresSource.cs
+++ b/DataAccessProvider.Postgres/PostgresSource.cs
@@ -7,7 +7,7 @@ using System.Data.Common;
 
 namespace DataAccessProvider.Postgres;
 
-public sealed class PostgresSource : BaseDatabaseSource<NpgsqlParameter, PostgresSourceParams>,
+public sealed class PostgresSource : BaseDatabaseSource<PostgresSourceParams>,
     IDataSource,
     IDataSource<PostgresSourceParams>
 {

--- a/DataAccessProvider.Snowflake/SnowflakeSource.cs
+++ b/DataAccessProvider.Snowflake/SnowflakeSource.cs
@@ -6,7 +6,7 @@ using System.Data;
 using System.Data.Common;
 
 namespace DataAccessProvider.Snowflake;
-public sealed class SnowflakeSource : BaseDatabaseSource<SnowflakeDbParameter, SnowflakeSourceParams>,
+public sealed class SnowflakeSource : BaseDatabaseSource<SnowflakeSourceParams>,
     IDataSource,
     IDataSource<SnowflakeSourceParams>
 {


### PR DESCRIPTION
### Motivation
- Simplify the base database abstraction by removing the unused `TParameter` generic from `BaseDatabaseSource` and consolidate parameterization to a single generic for source params.

### Description
- Removed the unused `TParameter` generic from all partial declarations of `BaseDatabaseSource` and adjusted the base partial types accordingly in `DataAccessProvider.Core/Abstractions/BaseDatabaseSource.cs`.
- Converted the typed derived abstraction to `BaseDatabaseSource<TDatabaseSourceParams> : BaseDatabaseSource, IDataSource<TDatabaseSourceParams>` and updated the region name to `BaseDatabaseSource<TDatabaseSourceParams>`.
- Updated concrete sources to inherit from the new signature, e.g. `MSSQLSource : BaseDatabaseSource<MSSQLSourceParams>`, and applied the same change for MySQL, Postgres, Oracle, and Snowflake source files.

### Testing
- Verified there are no remaining multi-generic base usages by running ripgrep searches such as `rg -n "BaseDatabaseSource<"` and `rg -n "BaseDatabaseSource<[^>]+,[^>]+>|BaseDatabaseSource<TParameter|where TParameter"` which returned no lingering matches.
- Attempted to run `dotnet build` to validate compilation, but it failed in this environment because the `dotnet` CLI is not available (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f60e0beec8324b908fb60ca8a0741)